### PR TITLE
Importing React from react-native has been deprecated

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var React = require('react-native');
-var {
-  StyleSheet,
-  Text,
-  View,
-} = React;
+import React from 'react';
+
+import {
+    Text,
+    View,
+    StyleSheet,
+} from 'react-native';
 
 var BoardView = require('./boardview.js');
 


### PR DESCRIPTION
With the current React Native release, setting up the project with the old style of importing React creates an error. This changes fixes that.
